### PR TITLE
API change

### DIFF
--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -24,8 +24,6 @@ use std::sync::mpsc::{Receiver, Sender};
 use tcp_connections::{listen, connect_tcp, TcpReader, TcpWriter, upgrade_tcp};
 use std::sync::{Arc, Mutex, Weak};
 use std::sync::mpsc;
-use cbor::{Encoder, Decoder};
-use rustc_serialize::{Decodable, Encodable};
 use std::fmt::Debug;
 
 pub type Bytes   = Vec<u8>;
@@ -298,7 +296,7 @@ mod test {
         let _ = enc.encode(&[value]);
         enc.into_bytes()
     }
-    
+
     fn decode<T>(bytes: Bytes) -> T where T: Decodable {
         let mut dec = Decoder::from_bytes(&bytes[..]);
         dec.decode().next().unwrap().unwrap()

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -78,9 +78,7 @@ impl ConnectionManager {
         ConnectionManager { state: state }
     }
 
-    // bootstrap_list will over
-    pub fn start(&self, bootstrap_list: Option<Vec<Endpoint>>,
-                 hint: Vec<PortAndProtocol>) -> IoResult<Vec<Endpoint>> {
+    pub fn start(&self, hint: Vec<PortAndProtocol>) -> IoResult<Vec<Endpoint>> {
         let weak_state = self.state.downgrade();
         let (event_receiver, listener) = try!(listen());
 
@@ -101,6 +99,10 @@ impl ConnectionManager {
         });
 
         Ok(vec![Endpoint::Tcp(local_addr)])
+    }
+
+    pub fn bootstrap(&self, bootstrap_list: Option<Vec<Endpoint>>) -> IoResult<Endpoint> {
+        unimplemented!()
     }
 
     pub fn connect(&self, endpoints: Vec<Endpoint>) {
@@ -329,11 +331,11 @@ mod test {
 
         let (cm1_i, cm1_o) = channel();
         let cm1 = ConnectionManager::new(cm1_i);
-        let cm1_eps = cm1.start(None, Vec::new()).unwrap();
+        let cm1_eps = cm1.start(Vec::new()).unwrap();
 
         let (cm2_i, cm2_o) = channel();
         let cm2 = ConnectionManager::new(cm2_i);
-        let cm2_eps = cm2.start(None, Vec::new()).unwrap();
+        let cm2_eps = cm2.start(Vec::new()).unwrap();
         cm2.connect(cm1_eps.clone());
 
         let runner1 = run_cm(cm1, cm1_o);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,9 @@
 extern crate rustc_serialize;
 extern crate cbor;
 
-pub mod tcp_connections;
+mod tcp_connections;
 pub mod connection_manager;
-pub mod beacon;
+mod beacon;
 
 pub use connection_manager::{Event, ConnectionManager};
 

--- a/src/tcp_connections.rs
+++ b/src/tcp_connections.rs
@@ -102,42 +102,6 @@ pub fn listen() ->  IoResult<(Receiver<(TcpStream, SocketAddr)>, TcpListener)> {
     Ok((rx, tcp_listener))
 }
 
-pub fn listen2() ->  IoResult<(Receiver<(TcpStream, SocketAddr)>, TcpListener)> {
-    let live_address = (("0.0.0.0"), 5483);
-    let any_address = (("0.0.0.0"), 0);
-    let tcp_listener = match TcpListener::bind(live_address) {
-        Ok(x) => x,
-        Err(_) => TcpListener::bind(&any_address).unwrap()
-    };
-    //println!("Listening on {:?}", tcp_listener.local_addr().unwrap());
-    let (tx, rx) = mpsc::channel();
-
-    let tcp_listener2 = try!(tcp_listener.try_clone());
-    spawn(move || {
-        loop {
-            // if tx.is_closed() {       // FIXME (Prakash)
-            //     break;
-            // }
-            match tcp_listener2.accept() {
-                Ok(stream) => {
-                    if tx.send(stream).is_err() {
-                        break;
-                    }
-                }
-                Err(ref e) if e.kind() == ErrorKind::TimedOut => {
-                    continue;
-                }
-                Err(e) => {
-                    //let _  = tx.error(e);
-                    break;
-                }
-            }
-            println!(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-        }
-    });
-    Ok((rx, tcp_listener))
-}
-
 // Almost a straight copy of https://github.com/TyOverby/wire/blob/master/src/tcp.rs
 /// Upgrades a TcpStream to a Sender-Receiver pair that you can use to send and
 /// receive objects automatically.  If there is an error decoding or encoding


### PR DESCRIPTION
There are few warnings, the `ConnectionManager::bootstrap` function isn't implemented, and few of the functions have limitations such as the `ConnectionManager::connect` function can now take only list of size = 1 endpoints. But the test compiles, runs and two nodes exchange a "hello" message.