### PR TITLE
beacon integration : MAID-952

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ homepage = "http://www.maidsafe.net"
 [dependencies]
 rustc-serialize = "*"
 cbor = "*"
+rand = "*"
 
 [[example]]
 name = "beacon_client"

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -183,7 +183,6 @@ pub fn seek_peers(port: Option<Port>) -> Vec<SocketAddr> {
 
 #[cfg(test)]
 mod test {
-    extern crate rand;
     use super::*;
     use std::net::{UdpSocket/*, lookup_addr, lookup_host*/};
     use std::thread;
@@ -191,7 +190,7 @@ mod test {
     use rand::*;
 
     fn next_port() -> u16 {
-            let mut port:u16 = rand::random();
+            let mut port:u16 = random();
             port = 1025 + port % 50000;
             port
     }

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -183,14 +183,22 @@ pub fn seek_peers(port: Option<Port>) -> Vec<SocketAddr> {
 
 #[cfg(test)]
 mod test {
+    extern crate rand;
     use super::*;
     use std::net::{UdpSocket/*, lookup_addr, lookup_host*/};
     use std::thread;
     use transport::{Port};
+    use rand::*;
+
+    fn next_port() -> u16 {
+            let mut port:u16 = rand::random();
+            port = 1025 + port % 50000;
+            port
+    }
 
 #[test]
     fn test_broadcast() {
-        let port = Port::Tcp(5493);
+        let port = Port::Tcp(next_port());
         // Start a normal socket and start listening for a broadcast
         let port2 = port.clone();
         thread::spawn(move || {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -316,6 +316,7 @@ fn start_writing_thread(state: WeakState,
 
 #[cfg(test)]
 mod test {
+    extern crate rand;
     use super::*;
     use std::thread::spawn;
     use std::thread;
@@ -323,6 +324,7 @@ mod test {
     use rustc_serialize::{Decodable, Encodable};
     use cbor::{Encoder, Decoder};
     use transport::{Port};
+    use rand::*;
 
     fn encode<T>(value: &T) -> Bytes where T: Encodable
     {
@@ -336,11 +338,17 @@ mod test {
         dec.decode().next().unwrap().unwrap()
     }
 
+    fn next_port() -> u16 {
+            let mut port:u16 = rand::random();
+            port = 1025 + port % 50000;
+            port
+    }
+
 #[test]
     fn bootstrap() {
         let (cm1_i, _) = channel();
         let cm1 = ConnectionManager::new(cm1_i);
-        let port = Port::Tcp(5484);
+        let port = Port::Tcp(next_port());
         let cm1_eps = cm1.start_listening(vec![Port::Tcp(0)], Some(port.clone())).unwrap();
 
         thread::sleep_ms(1000);
@@ -377,7 +385,7 @@ mod test {
             })
         };
 
-        let port = Port::Tcp(5485);
+        let port = Port::Tcp(next_port());
         let (cm1_i, cm1_o) = channel();
         let cm1 = ConnectionManager::new(cm1_i);
         let cm1_eps = cm1.start_listening(vec![Port::Tcp(0)], Some(port.clone())).unwrap();

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -316,7 +316,6 @@ fn start_writing_thread(state: WeakState,
 
 #[cfg(test)]
 mod test {
-    extern crate rand;
     use super::*;
     use std::thread::spawn;
     use std::thread;
@@ -339,7 +338,7 @@ mod test {
     }
 
     fn next_port() -> u16 {
-            let mut port:u16 = rand::random();
+            let mut port:u16 = random();
             port = 1025 + port % 50000;
             port
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 
 extern crate rustc_serialize;
 extern crate cbor;
+extern crate rand;
+
 
 mod tcp_connections;
 mod transport;


### PR DESCRIPTION
It seems that a WIP of this task which uses fixed port has been merged. That may cause trouble if two instances of same test run in parallel. This PR improves on the last PR by adding a function to generate random port numbers.