### PR TITLE
More work on crust_node example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,13 @@ license = "GPL-3.0"
 homepage = "http://maidsafe.net"
 
 [dependencies]
-rustc-serialize = "*"
 cbor = "*"
 docopt = "*"
-time = "*"
-sodiumoxide = "0.0.4"
 rand = "*"
+rustc-serialize = "*"
+sodiumoxide = "0.0.4"
+term = "*"
+time = "*"
 
 [[example]]
 name = "simple_sender"


### PR DESCRIPTION
Much of the work here is cosmetic, but the major improvement is using docopt to parse ongoing commands, and allowing docopt to understand endpoints (so invalid strings can't be passed as endpoints).

This PR is based off https://github.com/dirvine/crust/pull/78 and as per the comment there, I still haven't re-enabled the sending of random data.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/crust/81)
<!-- Reviewable:end -->
