### PR TITLE
Remove warnings

### DIFF
--- a/examples/crust_node.rs
+++ b/examples/crust_node.rs
@@ -29,10 +29,10 @@ extern crate time;
 
 use core::iter::FromIterator;
 use docopt::Docopt;
-use rand::random;
-use rand::Rng;
+// use rand::random;
+// use rand::Rng;
 use rustc_serialize::{Decodable, Decoder};
-use std::cmp;
+// use std::cmp;
 use std::sync::mpsc::channel;
 use std::io;
 use std::io::Write;
@@ -109,13 +109,13 @@ impl Decodable for PeerEndpoint {
     }
 }
 
-fn generate_random_vec_u8(size: usize) -> Vec<u8> {
-    let mut vec: Vec<u8> = Vec::with_capacity(size);
-    for _ in 0..size {
-        vec.push(random::<u8>());
-    }
-    vec
-}
+// fn generate_random_vec_u8(size: usize) -> Vec<u8> {
+//     let mut vec: Vec<u8> = Vec::with_capacity(size);
+//     for _ in 0..size {
+//         vec.push(random::<u8>());
+//     }
+//     vec
+// }
 
 fn print_input_line() {
     print!("Enter command (stop | connect <endpoint> | send <endpoint> <message>)>");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,14 @@
 //! Reliable p2p network connections in Rust with NAT traversal.
 //! One of the most needed libraries for any server-less / decentralised projects
 
-#![deny(missing_docs)]
-#![deny(unused_variables)]
-#![deny(dead_code)]
-#![deny(unused_must_use)]
+#![forbid(bad_style, missing_docs, warnings)]
+#![deny(deprecated, drop_with_repr_extern, improper_ctypes, non_shorthand_field_patterns,
+        overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
+        raw_pointer_derive, stable_features, unconditional_recursion, unknown_lints,
+        unsafe_code, unsigned_negation, unused, unused_allocation, unused_attributes,
+        unused_comparisons, unused_features, unused_parens, while_true)]
+#![warn(trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
+        unused_qualifications, unused_results, variant_size_differences)]
 #![doc(html_logo_url = "http://maidsafe.net/img/Resources/branding/maidsafe_logo.fab2.png",
        html_favicon_url = "http://maidsafe.net/img/favicon.ico",
        html_root_url = "http:///dirvine.github.io/crust/crust/")]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -79,7 +79,7 @@ impl Encodable for Endpoint {
 
 impl Decodable for Endpoint {
     fn decode<D: Decoder>(d: &mut D)->Result<Endpoint, D::Error> {
-        try!(d.read_u64());
+        let _ = try!(d.read_u64());
         let decoded: Vec<u8> = try!(Decodable::decode(d));
         let address: SocketAddr = beacon::parse_address(&decoded).unwrap();
 
@@ -135,7 +135,7 @@ pub enum Receiver {
 }
 
 impl Receiver {
-    pub fn receive(&mut self) -> IoResult<Bytes> {
+    pub fn receive(&self) -> IoResult<Bytes> {
         match *self {
             Receiver::Tcp(ref r) => {
                 match r.recv() {
@@ -220,25 +220,6 @@ pub fn accept(acceptor: &Acceptor) -> IoResult<Transport> {
                           remote_endpoint: Endpoint::Tcp(remote_endpoint),
                         })
         }
-    }
-}
-
-// FIXME: This function is deprecated in favor of Receiver::receive
-pub fn receive(receiver: &Receiver) -> IoResult<Bytes> {
-    match *receiver {
-        Receiver::Tcp(ref r) => r.recv().map_err(|e| {
-            io::Error::new(io::ErrorKind::NotConnected, e.description())
-        })
-    }
-}
-
-// FIXME: This function is deprecated in favor of Sender::send
-pub fn send(sender: &mut Sender, bytes: &Bytes) -> IoResult<()> {
-    match *sender {
-        Sender::Tcp(ref mut s) => s.send(&bytes).map_err(|_| {
-            // FIXME: This can be done better.
-            io::Error::new(io::ErrorKind::NotConnected, "can't send")
-        })
     }
 }
 


### PR DESCRIPTION
This includes Ross' PR #89

I've got an instance of `#[allow(dead_code)]` at the TCP `close` function.  It's needed to avoid the tests hanging, but it's telling that it's unused in the main codebase.  This could well be the cause of the hanging thread causing the Windows issue #84.

Once I get to the bottom of the issue I expect the `close` function will be getting used then, and the `#[allow...]` can go away.

There are also many places where I'm ignoring the result of `thread::spawn` calls, but again I'll be looking at these while debugging the Windows issue.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/crust/90)
<!-- Reviewable:end -->
